### PR TITLE
 feat: user/ product/ orders/ order_item/ payment/ stock/ wishlist/ wishlist_item 엔티티 추가 및 테이블 자동 생성

### DIFF
--- a/src/main/java/com/order/rush_order/domain/OrderItem.java
+++ b/src/main/java/com/order/rush_order/domain/OrderItem.java
@@ -1,0 +1,29 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private int quantity;
+
+    // 주문 상품 가격
+    @Column(nullable = false)
+    private float price;
+
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Orders order;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+}

--- a/src/main/java/com/order/rush_order/domain/Orders.java
+++ b/src/main/java/com/order/rush_order/domain/Orders.java
@@ -1,0 +1,28 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+
+public class Orders {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 주문 상태
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    // 주문 상품의 총 합
+    @Column(nullable = false)
+    private float total_price;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+    // created at
+}

--- a/src/main/java/com/order/rush_order/domain/Payment.java
+++ b/src/main/java/com/order/rush_order/domain/Payment.java
@@ -1,0 +1,27 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PayMethod method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PayStatus status;
+    // 결제일자 created_at
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Orders order;
+}

--- a/src/main/java/com/order/rush_order/domain/Product.java
+++ b/src/main/java/com/order/rush_order/domain/Product.java
@@ -1,0 +1,25 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    // 상품 판매가
+    @Column(nullable = false)
+    private float price;
+
+    // created at
+}

--- a/src/main/java/com/order/rush_order/domain/Stock.java
+++ b/src/main/java/com/order/rush_order/domain/Stock.java
@@ -1,0 +1,20 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Stock {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private Long quantity;
+}

--- a/src/main/java/com/order/rush_order/domain/User.java
+++ b/src/main/java/com/order/rush_order/domain/User.java
@@ -1,0 +1,31 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 11)
+    private String contact;
+
+    @Column(nullable = false)
+    private String address;
+
+
+}

--- a/src/main/java/com/order/rush_order/domain/Wishlist.java
+++ b/src/main/java/com/order/rush_order/domain/Wishlist.java
@@ -1,0 +1,21 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Wishlist {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+
+    //created at
+}

--- a/src/main/java/com/order/rush_order/domain/WishlistItem.java
+++ b/src/main/java/com/order/rush_order/domain/WishlistItem.java
@@ -1,0 +1,26 @@
+package com.order.rush_order.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class WishlistItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wish_list_id")
+    private Wishlist wishlist;
+
+}


### PR DESCRIPTION
Closes #2

## 📌 Summary
- 엔티티 추가 및 테이블 자동 생성

## 🛠 Changes
- **User 도메인**: user 추가
- **Product 도메인**: product, stock 추가
- **Order 도메인**: orders, order_item 추가
- **Wishlist 도메인**: wishlist, wishlist_item 추가
- **payment 도메인**: payment 추가

## ✅ CheckList
- [ ] MySQL 테이블이 정상적으로 생성되는지 확인

### **Docker 관련 이슈 해결 내용 (참고)**
-**이슈 내용**-
- 로컬 DB와 컨테이너 DB간 충돌
-**해결**-
    - docker-compose 의존성 주석 → 동작은 가능(일시적인 해결)
-**궁금점**-
    - 로컬 개발 환경에서 개발 후 마지막에 도커 의존성을 추가하여 데이터 migrate을 하는 방식으로 접근 해야하는지
