### PR TITLE
feat: 장바구니 api -조회/ 추가/ 수량/ 삭제

### DIFF
--- a/src/main/java/com/order/rush_order/order/controller/cart/CartController.java
+++ b/src/main/java/com/order/rush_order/order/controller/cart/CartController.java
@@ -1,0 +1,64 @@
+package com.order.rush_order.order.controller.cart;
+
+import com.order.rush_order.common.security.UserDetailsImpl;
+import com.order.rush_order.order.dto.request.CartQuantityDto;
+import com.order.rush_order.order.dto.response.CartItemDto;
+import com.order.rush_order.order.service.cart.CartService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+
+    // 특정 유저 장바구니 상품 조회
+    @GetMapping()
+    public List<CartItemDto> getAllCartItems(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return cartService.getCartItems(userDetails.getUsername());
+    }
+
+    @PostMapping("/add/{productId}")
+    public ResponseEntity<?> addProductToCart(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody CartQuantityDto dto
+    )
+    {
+        cartService.addProductToCart(productId, userDetails.getUsername(), dto);
+        return ResponseEntity.ok("상품이 장바구니에 추가 되었습니다.");
+    }
+
+    // 수량 업데이트 (증가/감소)
+    @PatchMapping("/update/{productId}")
+    public ResponseEntity<CartItemDto> updateProductQuantity(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody CartQuantityDto dto)
+    {
+        CartItemDto updatedCartItem = cartService.updateProductQuantity(
+                productId, userDetails.getUsername(), dto.getQuantity());
+
+        return ResponseEntity.ok(updatedCartItem);
+    }
+
+    // 추후에 softdelete 방식으로 변경
+    @DeleteMapping("/remove/{productId}")
+    public ResponseEntity<?> removeProductFromCart(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        // 장바구니에서 항목 제거
+        cartService.removeProductFromCart(productId, userDetails.getUsername());
+
+        // 성공 메시지 반환
+        return ResponseEntity.ok("장바구니에서 상품이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/order/rush_order/order/dto/request/CartQuantityDto.java
+++ b/src/main/java/com/order/rush_order/order/dto/request/CartQuantityDto.java
@@ -1,0 +1,8 @@
+package com.order.rush_order.order.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CartQuantityDto {
+    private long quantity;
+}

--- a/src/main/java/com/order/rush_order/order/dto/response/CartItemDto.java
+++ b/src/main/java/com/order/rush_order/order/dto/response/CartItemDto.java
@@ -1,0 +1,32 @@
+package com.order.rush_order.order.dto.response;
+
+import com.order.rush_order.product.dto.ProductSummaryResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class CartItemDto extends ProductSummaryResponseDto{
+    private long cartId;
+    private long quantity;
+
+    private BigDecimal cartPrice;
+
+    @Builder
+    public CartItemDto(
+            Long cartId,
+            long productId,
+            String name,
+            BigDecimal price,
+            long quantity,
+            BigDecimal cartPrice
+    ) {
+        super(productId, name, price);
+        this.cartId = cartId;
+        this.quantity = quantity;
+        this.cartPrice = cartPrice;
+    }
+}

--- a/src/main/java/com/order/rush_order/order/entity/Cart.java
+++ b/src/main/java/com/order/rush_order/order/entity/Cart.java
@@ -1,0 +1,82 @@
+package com.order.rush_order.order.entity;
+
+import com.order.rush_order.member.entity.Users;
+import com.order.rush_order.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Cart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @Column(nullable = false)
+    private long quantity;
+
+    // 장바구니 특정 상품의 총 비용
+    @Column(nullable = false)
+    private BigDecimal cartPrice;
+
+    @Builder
+    public Cart(Product product, Users user, long quantity) {
+        this.product = product;
+        this.user = user;
+        this.quantity = quantity;
+        this.cartPrice = calculateCartPrice();
+    }
+
+    public static Cart toEntity(Users user, Product product, long quantity){
+        return Cart.builder()
+                .product(product)
+                .user(user)
+                .quantity(quantity)
+                .build();
+    }
+
+    // cartPrice 계산 메서드
+    public BigDecimal calculateCartPrice() {
+        return product.getPrice().multiply(BigDecimal.valueOf(quantity));
+    }
+
+    // 수량 업데이트 메서드
+    public void updateQuantity(long newQuantity) {
+        if (newQuantity < 0) {
+            throw new IllegalArgumentException("수량은 음수일 수 없습니다.");
+        }
+        this.quantity = newQuantity;
+        this.cartPrice = calculateCartPrice();  // 수량 변경 시 가격 재계산
+    }
+
+    // 상품 추가(수량 증가) 메서드
+    public void addQuantity(long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("추가 수량은 양수여야 합니다.");
+        }
+        this.quantity += amount;
+        this.cartPrice = calculateCartPrice();  // 수량 증가 후 가격 재계산
+    }
+
+    // 상품 제거(수량 감소) 메서드
+    public void subtractQuantity(long amount) {
+        if (amount <= 0 || this.quantity < amount) {
+            throw new IllegalArgumentException("잘못된 수량 감소 요청입니다.");
+        }
+        this.quantity -= amount;
+        this.cartPrice = calculateCartPrice();  // 수량 감소 후 가격 재계산
+    }
+}

--- a/src/main/java/com/order/rush_order/order/mapper/CartMapper.java
+++ b/src/main/java/com/order/rush_order/order/mapper/CartMapper.java
@@ -1,0 +1,23 @@
+package com.order.rush_order.order.mapper;
+
+import com.order.rush_order.member.entity.Users;
+import com.order.rush_order.order.dto.response.CartItemDto;
+import com.order.rush_order.order.entity.Cart;
+import com.order.rush_order.product.entity.Product;
+
+public class CartMapper {
+
+    public static CartItemDto toItemDto(Cart cart){
+        Product product = cart.getProduct();  // Cart에서 Product 객체 가져오기
+
+        return CartItemDto.builder()
+                .cartId(cart.getId())
+                .productId(product.getId())
+                .name(product.getName())
+                .price(product.getPrice())
+                .quantity(cart.getQuantity())
+                .cartPrice(cart.getCartPrice())  // 계산된 총 가격 반영
+                .build();
+    }
+}
+

--- a/src/main/java/com/order/rush_order/order/repository/cart/CartRepository.java
+++ b/src/main/java/com/order/rush_order/order/repository/cart/CartRepository.java
@@ -1,0 +1,20 @@
+package com.order.rush_order.order.repository.cart;
+
+import com.order.rush_order.member.entity.Users;
+import com.order.rush_order.order.dto.response.CartItemDto;
+import com.order.rush_order.order.entity.Cart;
+import com.order.rush_order.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    boolean existsByUserAndProduct(Users user, Product product);
+
+    List<CartItemDto> findAllByUser(Users user);
+
+    Optional<Cart> findByUserAndProduct(Users user, Product product);
+
+    List<Cart> findByUser(Users user);
+}

--- a/src/main/java/com/order/rush_order/order/service/cart/CartService.java
+++ b/src/main/java/com/order/rush_order/order/service/cart/CartService.java
@@ -1,0 +1,89 @@
+package com.order.rush_order.order.service.cart;
+
+import com.order.rush_order.member.entity.Users;
+import com.order.rush_order.member.service.UserService;
+import com.order.rush_order.order.dto.request.CartQuantityDto;
+import com.order.rush_order.order.dto.response.CartItemDto;
+import com.order.rush_order.order.entity.Cart;
+import com.order.rush_order.order.mapper.CartMapper;
+import com.order.rush_order.order.repository.cart.CartRepository;
+import com.order.rush_order.product.entity.Product;
+import com.order.rush_order.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final UserService userService;
+    private final ProductService productService;
+
+
+    // 장바구니 조회
+    public List<CartItemDto> getCartItems(String email) {
+        Users user = userService.getUserByEmail(email);
+        return cartRepository.findAllByUser(user);
+    }
+
+    public void addProductToCart(Long productId, String email, CartQuantityDto dto) {
+        Users existUser = userService.getUserByEmail(email);
+        Product existProduct = productService.getProductById(productId);
+
+        // 검증
+        if (cartRepository.existsByUserAndProduct(existUser, existProduct)) {
+            throw new IllegalStateException("이미 장바구니에 추가된 상품입니다.");
+        }
+
+        // 장바구니 아이템 추가/ 수량, 제품 비용 계산
+        Cart cartItem = Cart.toEntity(existUser, existProduct, dto.getQuantity());
+        cartRepository.save(cartItem);
+    }
+
+
+    // 수량 변경 메서드 (증가/감소)
+    @Transactional
+    public CartItemDto updateProductQuantity(Long productId, String email, long quantityChange) {
+        // 해당 상품 검증
+        Cart cart = findCartItem(productId, email);
+
+        // 수량 업데이트: 양수면 증가, 음수면 감소
+        if (quantityChange > 0) {
+            cart.addQuantity(quantityChange);
+        } else if (quantityChange < 0) {
+            cart.subtractQuantity(Math.abs(quantityChange));
+        }
+
+        // 수량이 0이면 삭제
+        if (cart.getQuantity() == 0) {
+            cartRepository.delete(cart);
+            return null;  // 0이 된 경우 null 반환
+        } else {
+            cartRepository.save(cart);
+            return CartMapper.toItemDto(cart);  // 변경된 데이터 반환
+        }
+    }
+
+    // 장바구니 항목 삭제
+    @Transactional
+    public void removeProductFromCart(Long productId, String email) {
+        Cart cart = findCartItem(productId, email);
+        cartRepository.delete(cart);
+    }
+
+    // 사용자와 상품으로 장바구니 항목 조회
+    private Cart findCartItem(Long productId, String email) {
+        Users user = userService.getUserByEmail(email);
+        Product product = productService.getProductById(productId);
+
+        return cartRepository.findByUserAndProduct(user, product)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니에 해당 상품이 없습니다."));
+    }
+
+
+
+}


### PR DESCRIPTION
Closes #10

## 📌 Summary
- 장바구니 조회/ 추가/ 재고 수량 업데이트, 삭제 API 추가

## 🛠 Changes
- **CART** add, getAllCart, update, remove

## 🚀 Issue 해결


## ✅ CheckList
- [ ] Cart CRUD 기능 테스트
